### PR TITLE
refactor: define ContentState without typealias

### DIFF
--- a/LiveActivity/Attributes.swift
+++ b/LiveActivity/Attributes.swift
@@ -8,6 +8,4 @@ public struct NursingActivityAttributes: ActivityAttributes {
         let startTime: Date
         let isActive: Bool
     }
-    
-    public typealias ContentState = ContentState
 }

--- a/_shared/NursingActivityAttributes.swift
+++ b/_shared/NursingActivityAttributes.swift
@@ -49,8 +49,6 @@ public struct NursingActivityAttributes: ActivityAttributes {
             return pausedAt == nil
         }
     }
-    
-    public typealias ContentState = ContentState
-    
+
     public init() {}
 }


### PR DESCRIPTION
## Summary
- remove recursive ContentState typealias from live activity attributes
- eliminate redundant typealias in shared NursingActivityAttributes

## Testing
- `swiftc LiveActivity/*.swift -o LiveActivityApp` *(fails: no such module 'ActivityKit')*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6890497840e8833289da42c48101ac4f