### PR TITLE
Add pause/resume/complete activity fallbacks

### DIFF
--- a/modules/live-activity-control/src/LiveActivityControlModule.ts
+++ b/modules/live-activity-control/src/LiveActivityControlModule.ts
@@ -21,6 +21,26 @@ export default NativeModulesProxy.LiveActivityControl ?? {
       message: 'Live Activities not supported on this platform'
     };
   },
+  async pauseActivity(_activityId?: string) {
+    return {
+      success: false,
+      message: 'Live Activities not supported on this platform',
+      elapsedTime: 0
+    };
+  },
+  async resumeActivity(_activityId?: string) {
+    return {
+      success: false,
+      message: 'Live Activities not supported on this platform'
+    };
+  },
+  async completeActivity(_activityId?: string) {
+    return {
+      success: false,
+      message: 'Live Activities not supported on this platform',
+      elapsedTime: 0
+    };
+  },
   async areActivitiesEnabled() {
     return false;
   }


### PR DESCRIPTION
## Summary
- extend LiveActivityControl fallback with pause, resume and complete methods returning status objects

## Testing
- `npx tsc src/index.ts src/LiveActivityControlModule.ts --module commonjs --target es2019 --outDir test-build --skipLibCheck`
- `node - <<'NODE'
const Module = require('module');
const originalRequire = Module.prototype.require;
Module.prototype.require = function(path){
  if(path === 'expo-modules-core'){
    return { NativeModulesProxy: {} };
  }
  return originalRequire.call(this, path);
};
const mod = require('./test-build');
(async () => {
  console.log('pause', await mod.pauseActivity());
  console.log('resume', await mod.resumeActivity());
  console.log('complete', await mod.completeActivity());
})();
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68904963f49c8332bb03205c1d55fb92