### PR TITLE
feat: add live activity control module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ ios/
 android/
 .expo/
 *.log
+!modules/live-activity-control/ios/

--- a/modules/live-activity-control/build/LiveActivityControlModule.d.ts
+++ b/modules/live-activity-control/build/LiveActivityControlModule.d.ts
@@ -1,0 +1,17 @@
+export type LiveActivityResult = {
+    success: boolean;
+    message: string;
+    activityId?: string;
+    elapsedTime?: number;
+};
+export interface LiveActivityControlModule {
+    startActivity(sideOrName: string, babyNameOrIcon?: string): Promise<LiveActivityResult>;
+    endActivity(): Promise<LiveActivityResult>;
+    updateActivity(side: string): Promise<LiveActivityResult>;
+    pauseActivity(activityId?: string): Promise<LiveActivityResult>;
+    resumeActivity(activityId?: string): Promise<LiveActivityResult>;
+    completeActivity(activityId?: string): Promise<LiveActivityResult>;
+    areActivitiesEnabled(): Promise<boolean>;
+}
+declare const _default: LiveActivityControlModule;
+export default _default;

--- a/modules/live-activity-control/build/LiveActivityControlModule.js
+++ b/modules/live-activity-control/build/LiveActivityControlModule.js
@@ -1,0 +1,4 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var expo_modules_core_1 = require("expo-modules-core");
+exports.default = (0, expo_modules_core_1.requireNativeModule)('LiveActivityControl');

--- a/modules/live-activity-control/build/index.d.ts
+++ b/modules/live-activity-control/build/index.d.ts
@@ -1,0 +1,36 @@
+import LiveActivityControlModule from './LiveActivityControlModule';
+export declare function startActivity(side: 'left' | 'right', babyName?: string): Promise<{
+    success: boolean;
+    message: string;
+    activityId?: string;
+}>;
+export declare function endActivity(): Promise<{
+    success: boolean;
+    message: string;
+    elapsedTime?: number;
+}>;
+export declare function updateActivity(side: 'left' | 'right'): Promise<{
+    success: boolean;
+    message: string;
+}>;
+export declare function areActivitiesEnabled(): Promise<boolean>;
+export declare function startNursingActivity(activityName: string, activityIcon: string): Promise<{
+    success: boolean;
+    message: string;
+    activityId?: string;
+}>;
+export declare function pauseActivity(activityId?: string): Promise<{
+    success: boolean;
+    message: string;
+    elapsedTime?: number;
+}>;
+export declare function resumeActivity(activityId?: string): Promise<{
+    success: boolean;
+    message: string;
+}>;
+export declare function completeActivity(activityId?: string): Promise<{
+    success: boolean;
+    message: string;
+    elapsedTime?: number;
+}>;
+export { LiveActivityControlModule };

--- a/modules/live-activity-control/build/index.js
+++ b/modules/live-activity-control/build/index.js
@@ -1,0 +1,131 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g = Object.create((typeof Iterator === "function" ? Iterator : Object).prototype);
+    return g.next = verb(0), g["throw"] = verb(1), g["return"] = verb(2), typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (g && (g = 0, op[0] && (_ = 0)), _) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.LiveActivityControlModule = void 0;
+exports.startActivity = startActivity;
+exports.endActivity = endActivity;
+exports.updateActivity = updateActivity;
+exports.areActivitiesEnabled = areActivitiesEnabled;
+exports.startNursingActivity = startNursingActivity;
+exports.pauseActivity = pauseActivity;
+exports.resumeActivity = resumeActivity;
+exports.completeActivity = completeActivity;
+var LiveActivityControlModule_1 = require("./LiveActivityControlModule");
+exports.LiveActivityControlModule = LiveActivityControlModule_1.default;
+// Legacy compatibility functions
+function startActivity(side, babyName) {
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0: return [4 /*yield*/, LiveActivityControlModule_1.default.startActivity(side, babyName)];
+                case 1: return [2 /*return*/, _a.sent()];
+            }
+        });
+    });
+}
+function endActivity() {
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0: return [4 /*yield*/, LiveActivityControlModule_1.default.endActivity()];
+                case 1: return [2 /*return*/, _a.sent()];
+            }
+        });
+    });
+}
+function updateActivity(side) {
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0: return [4 /*yield*/, LiveActivityControlModule_1.default.updateActivity(side)];
+                case 1: return [2 /*return*/, _a.sent()];
+            }
+        });
+    });
+}
+function areActivitiesEnabled() {
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0: return [4 /*yield*/, LiveActivityControlModule_1.default.areActivitiesEnabled()];
+                case 1: return [2 /*return*/, _a.sent()];
+            }
+        });
+    });
+}
+// Enhanced functions with pause/resume support
+function startNursingActivity(activityName, activityIcon) {
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0: return [4 /*yield*/, LiveActivityControlModule_1.default.startActivity(activityName, activityIcon)];
+                case 1: return [2 /*return*/, _a.sent()];
+            }
+        });
+    });
+}
+function pauseActivity(activityId) {
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0: return [4 /*yield*/, LiveActivityControlModule_1.default.pauseActivity(activityId)];
+                case 1: return [2 /*return*/, _a.sent()];
+            }
+        });
+    });
+}
+function resumeActivity(activityId) {
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0: return [4 /*yield*/, LiveActivityControlModule_1.default.resumeActivity(activityId)];
+                case 1: return [2 /*return*/, _a.sent()];
+            }
+        });
+    });
+}
+function completeActivity(activityId) {
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0: return [4 /*yield*/, LiveActivityControlModule_1.default.completeActivity(activityId)];
+                case 1: return [2 /*return*/, _a.sent()];
+            }
+        });
+    });
+}

--- a/modules/live-activity-control/ios/Attributes.swift
+++ b/modules/live-activity-control/ios/Attributes.swift
@@ -1,0 +1,29 @@
+import ActivityKit
+import Foundation
+
+public struct NursingActivityAttributes: ActivityAttributes {
+    public struct ContentState: Codable, Hashable {
+        public var activityName: String
+        public var activityIcon: String
+        public var startedAt: Date
+        public var pausedAt: Date?
+        public var babyName: String?
+
+        public init(activityName: String, activityIcon: String, startedAt: Date, pausedAt: Date?, babyName: String?) {
+            self.activityName = activityName
+            self.activityIcon = activityIcon
+            self.startedAt = startedAt
+            self.pausedAt = pausedAt
+            self.babyName = babyName
+        }
+
+        public func getElapsedTimeInSeconds() -> Double {
+            let endDate = pausedAt ?? Date()
+            return endDate.timeIntervalSince(startedAt)
+        }
+
+        public func isRunning() -> Bool {
+            return pausedAt == nil
+        }
+    }
+}

--- a/modules/live-activity-control/ios/LiveActivityControlModule.swift
+++ b/modules/live-activity-control/ios/LiveActivityControlModule.swift
@@ -1,0 +1,47 @@
+import ExpoModulesCore
+import ActivityKit
+import Foundation
+
+public class LiveActivityControlModule: Module {
+    private var nursingModule = NursingLiveActivityModule()
+    
+    public func definition() -> ModuleDefinition {
+        Name("LiveActivityControl")
+
+        // Legacy compatibility functions - delegate to new module
+        AsyncFunction("startActivity") { (side: String, babyName: String?) -> [String: Any] in
+            let activityName = side.capitalized + " Nursing"
+            let activityIcon = "🍼"
+            return await self.nursingModule.startActivity(activityName: activityName, activityIcon: activityIcon)
+        }
+
+        AsyncFunction("endActivity") { () -> [String: Any] in
+            return await self.nursingModule.completeActivity(activityId: nil)
+        }
+
+        AsyncFunction("updateActivity") { (side: String) -> [String: Any] in
+            // For legacy compatibility, treat as restart with new side
+            let activityName = side.capitalized + " Nursing"
+            let activityIcon = "🍼"
+            return await self.nursingModule.startActivity(activityName: activityName, activityIcon: activityIcon)
+        }
+
+        AsyncFunction("areActivitiesEnabled") { () -> Bool in
+            return self.nursingModule.areActivitiesEnabled()
+        }
+        
+        // Expose new enhanced functions
+        AsyncFunction("pauseActivity") { (activityId: String?) -> [String: Any] in
+            return await self.nursingModule.pauseActivity(activityId: activityId)
+        }
+        
+        AsyncFunction("resumeActivity") { (activityId: String?) -> [String: Any] in
+            return await self.nursingModule.resumeActivity(activityId: activityId)
+        }
+        
+        AsyncFunction("completeActivity") { (activityId: String?) -> [String: Any] in
+            return await self.nursingModule.completeActivity(activityId: activityId)
+        }
+    }
+}
+

--- a/modules/live-activity-control/ios/NursingLiveActivityModule.swift
+++ b/modules/live-activity-control/ios/NursingLiveActivityModule.swift
@@ -1,0 +1,278 @@
+import ExpoModulesCore
+import ActivityKit
+import Foundation
+
+public class NursingLiveActivityModule: Module {
+    private var currentActivity: Activity<NursingActivityAttributes>?
+    private var currentActivityId: String?
+    private var startedAt: Date?
+    private var pausedAt: Date?
+    
+    public func definition() -> ModuleDefinition {
+        Name("NursingLiveActivityModule")
+        
+        // Events to JavaScript
+        Events("onLiveActivityUpdate", "onWidgetCompleteActivity", "sendTimerUpdateEvent")
+        
+        // Main functions exposed to JS
+        AsyncFunction("startActivity") { (activityName: String, activityIcon: String) -> [String: Any] in
+            return await self.startActivity(activityName: activityName, activityIcon: activityIcon)
+        }
+        
+        AsyncFunction("pauseActivity") { (activityId: String?) -> [String: Any] in
+            return await self.pauseActivity(activityId: activityId)
+        }
+        
+        AsyncFunction("resumeActivity") { (activityId: String?) -> [String: Any] in
+            return await self.resumeActivity(activityId: activityId)
+        }
+        
+        AsyncFunction("completeActivity") { (activityId: String?) -> [String: Any] in
+            return await self.completeActivity(activityId: activityId)
+        }
+        
+        AsyncFunction("areActivitiesEnabled") { () -> Bool in
+            return self.areActivitiesEnabled()
+        }
+        
+        OnCreate {
+            self.setupNotificationListeners()
+        }
+    }
+    
+    @available(iOS 16.1, *)
+    private func startActivity(activityName: String, activityIcon: String) async -> [String: Any] {
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else {
+            return [
+                "success": false,
+                "message": "Live Activities are not enabled"
+            ]
+        }
+        
+        // End any existing activity first
+        await completeActivity(activityId: nil)
+        
+        let attributes = NursingActivityAttributes()
+        let startTime = Date()
+        self.startedAt = startTime
+        self.pausedAt = nil
+        self.currentActivityId = UUID().uuidString
+        
+        let contentState = NursingActivityAttributes.ContentState(
+            activityName: activityName,
+            activityIcon: activityIcon,
+            startedAt: startTime,
+            pausedAt: nil,
+            babyName: nil // Can be enhanced later
+        )
+        
+        do {
+            let activity = try Activity<NursingActivityAttributes>.request(
+                attributes: attributes,
+                content: .init(state: contentState, staleDate: nil),
+                pushType: .token
+            )
+            
+            self.currentActivity = activity
+            
+            // Send update to JS
+            sendEvent("onLiveActivityUpdate", [
+                "state": "started",
+                "elapsedTime": 0,
+                "activityId": currentActivityId ?? ""
+            ])
+            
+            return [
+                "success": true,
+                "message": "Live Activity started successfully",
+                "activityId": currentActivityId ?? ""
+            ]
+        } catch {
+            return [
+                "success": false,
+                "message": "Failed to start Live Activity: \(error.localizedDescription)"
+            ]
+        }
+    }
+    
+    @available(iOS 16.1, *)
+    private func pauseActivity(activityId: String?) async -> [String: Any] {
+        guard let activity = currentActivity else {
+            return [
+                "success": false,
+                "message": "No active Live Activity to pause"
+            ]
+        }
+        
+        let pauseTime = Date()
+        self.pausedAt = pauseTime
+        
+        let updatedState = NursingActivityAttributes.ContentState(
+            activityName: activity.content.state.activityName,
+            activityIcon: activity.content.state.activityIcon,
+            startedAt: activity.content.state.startedAt,
+            pausedAt: pauseTime,
+            babyName: activity.content.state.babyName
+        )
+        
+        await activity.update(.init(state: updatedState, staleDate: nil))
+        
+        let elapsedTime = pauseTime.timeIntervalSince(activity.content.state.startedAt)
+        
+        // Send update to JS
+        sendEvent("onLiveActivityUpdate", [
+            "state": "paused",
+            "elapsedTime": elapsedTime,
+            "activityId": currentActivityId ?? ""
+        ])
+        
+        return [
+            "success": true,
+            "message": "Live Activity paused successfully",
+            "elapsedTime": elapsedTime
+        ]
+    }
+    
+    @available(iOS 16.1, *)
+    private func resumeActivity(activityId: String?) async -> [String: Any] {
+        guard let activity = currentActivity else {
+            return [
+                "success": false,
+                "message": "No active Live Activity to resume"
+            ]
+        }
+        
+        guard let pausedTime = self.pausedAt else {
+            return [
+                "success": false,
+                "message": "Activity is not paused"
+            ]
+        }
+        
+        // Calculate the time spent paused and adjust start time
+        let pauseDuration = Date().timeIntervalSince(pausedTime)
+        let adjustedStartTime = activity.content.state.startedAt.addingTimeInterval(pauseDuration)
+        
+        self.startedAt = adjustedStartTime
+        self.pausedAt = nil
+        
+        let updatedState = NursingActivityAttributes.ContentState(
+            activityName: activity.content.state.activityName,
+            activityIcon: activity.content.state.activityIcon,
+            startedAt: adjustedStartTime,
+            pausedAt: nil,
+            babyName: activity.content.state.babyName
+        )
+        
+        await activity.update(.init(state: updatedState, staleDate: nil))
+        
+        // Send update to JS
+        sendEvent("onLiveActivityUpdate", [
+            "state": "resumed",
+            "elapsedTime": activity.content.state.getElapsedTimeInSeconds(),
+            "activityId": currentActivityId ?? ""
+        ])
+        
+        return [
+            "success": true,
+            "message": "Live Activity resumed successfully"
+        ]
+    }
+    
+    @available(iOS 16.1, *)
+    private func completeActivity(activityId: String?) async -> [String: Any] {
+        guard let activity = currentActivity else {
+            return [
+                "success": true,
+                "message": "No active Live Activity to complete"
+            ]
+        }
+        
+        let elapsedTime = activity.content.state.getElapsedTimeInSeconds()
+        
+        await activity.end(nil, dismissalPolicy: .immediate)
+        currentActivity = nil
+        currentActivityId = nil
+        startedAt = nil
+        pausedAt = nil
+        
+        // Send completion event to JS
+        sendEvent("onWidgetCompleteActivity", [
+            "activityId": activityId ?? "",
+            "elapsedTime": elapsedTime
+        ])
+        
+        return [
+            "success": true,
+            "message": "Live Activity completed successfully",
+            "elapsedTime": elapsedTime
+        ]
+    }
+    
+    private func areActivitiesEnabled() -> Bool {
+        if #available(iOS 16.1, *) {
+            return ActivityAuthorizationInfo().areActivitiesEnabled
+        } else {
+            return false
+        }
+    }
+    
+    // Setup notification listeners for widget interactions
+    private func setupNotificationListeners() {
+        NotificationCenter.default.addObserver(
+            forName: NSNotification.Name("pauseTimerFromWidget"),
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task {
+                await self?.performPause()
+            }
+        }
+        
+        NotificationCenter.default.addObserver(
+            forName: NSNotification.Name("resumeTimerFromWidget"),
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task {
+                await self?.performResume()
+            }
+        }
+        
+        NotificationCenter.default.addObserver(
+            forName: NSNotification.Name("completeActivityFromWidget"),
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task {
+                await self?.performComplete()
+            }
+        }
+    }
+    
+    @available(iOS 16.1, *)
+    private func performPause() async {
+        let _ = await pauseActivity(activityId: currentActivityId)
+    }
+    
+    @available(iOS 16.1, *)
+    private func performResume() async {
+        let _ = await resumeActivity(activityId: currentActivityId)
+    }
+    
+    @available(iOS 16.1, *)
+    private func performComplete() async {
+        let _ = await completeActivity(activityId: currentActivityId)
+    }
+    
+    // Send timer update events periodically
+    func sendTimerUpdateEvent() {
+        guard let activity = currentActivity else { return }
+        
+        sendEvent("sendTimerUpdateEvent", [
+            "elapsedTime": activity.content.state.getElapsedTimeInSeconds(),
+            "isRunning": activity.content.state.isRunning(),
+            "activityId": currentActivityId ?? ""
+        ])
+    }
+}

--- a/modules/live-activity-control/src/LiveActivityControlModule.ts
+++ b/modules/live-activity-control/src/LiveActivityControlModule.ts
@@ -1,27 +1,21 @@
-import { NativeModulesProxy } from 'expo-modules-core';
+import { requireNativeModule } from 'expo-modules-core';
 
-// Import the native module. On web, it will be resolved to a web-specific implementation
-// and on native platforms to the native implementation.
-export default NativeModulesProxy.LiveActivityControl ?? {
-  async startActivity(side: string, babyName?: string) {
-    return {
-      success: false,
-      message: 'Live Activities not supported on this platform'
-    };
-  },
-  async endActivity() {
-    return {
-      success: false,
-      message: 'Live Activities not supported on this platform'
-    };
-  },
-  async updateActivity(side: string) {
-    return {
-      success: false,
-      message: 'Live Activities not supported on this platform'
-    };
-  },
-  async areActivitiesEnabled() {
-    return false;
-  }
+export type LiveActivityResult = {
+  success: boolean;
+  message: string;
+  activityId?: string;
+  elapsedTime?: number;
 };
+
+export interface LiveActivityControlModule {
+  startActivity(sideOrName: string, babyNameOrIcon?: string): Promise<LiveActivityResult>;
+  endActivity(): Promise<LiveActivityResult>;
+  updateActivity(side: string): Promise<LiveActivityResult>;
+  pauseActivity(activityId?: string): Promise<LiveActivityResult>;
+  resumeActivity(activityId?: string): Promise<LiveActivityResult>;
+  completeActivity(activityId?: string): Promise<LiveActivityResult>;
+  areActivitiesEnabled(): Promise<boolean>;
+}
+
+export default requireNativeModule<LiveActivityControlModule>('LiveActivityControl');
+

--- a/modules/live-activity-control/src/index.ts
+++ b/modules/live-activity-control/src/index.ts
@@ -1,4 +1,3 @@
-import { NativeModulesProxy } from 'expo-modules-core';
 import LiveActivityControlModule from './LiveActivityControlModule';
 
 // Legacy compatibility functions
@@ -62,3 +61,4 @@ export async function completeActivity(activityId?: string): Promise<{
 }
 
 export { LiveActivityControlModule };
+


### PR DESCRIPTION
## Summary
- add ActivityKit-powered nursing session controller in Swift
- expose LiveActivityControl functions to JS via Expo modules
- wire up TS module to native implementation and compile

## Testing
- `npx expo-module build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/expo-module)*
- `npm run lint` *(fails: ESLint couldn't find the config "@typescript-eslint")*
- `npm run type-check` *(fails: RangeError: Maximum call stack size exceeded)*
- `npx expo prebuild --platform ios --no-install` *(fails: Expo config missing ios.appleTeamId; npm view expo-template-bare-minimum@sdk-53 dist --json exited with non-zero code: 1)*

------
https://chatgpt.com/codex/tasks/task_e_6890495c98988332ae88a1d4a0cb2204